### PR TITLE
Implement JWT authentication middleware

### DIFF
--- a/WebApi/Controllers/AuthController.cs
+++ b/WebApi/Controllers/AuthController.cs
@@ -1,0 +1,41 @@
+using System.IdentityModel.Tokens.Jwt;
+using System.Security.Claims;
+using System.Text;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.IdentityModel.Tokens;
+using WebApi.Models;
+
+namespace WebApi.Controllers;
+
+[ApiController]
+[Route("auth")]
+public class AuthController : ControllerBase
+{
+    private readonly IConfiguration _config;
+
+    public AuthController(IConfiguration config)
+    {
+        _config = config;
+    }
+
+    [HttpPost("token")]
+    public IActionResult GetToken([FromBody] LoginRequest login)
+    {
+        if (login.Username != "admin" || login.Password != "admin")
+        {
+            return Unauthorized();
+        }
+
+        var key = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(_config["Jwt:Key"]!));
+        var creds = new SigningCredentials(key, SecurityAlgorithms.HmacSha256);
+
+        var token = new JwtSecurityToken(
+            issuer: _config["Jwt:Issuer"],
+            audience: _config["Jwt:Audience"],
+            claims: new[] { new Claim(ClaimTypes.Name, login.Username) },
+            expires: DateTime.UtcNow.AddHours(1),
+            signingCredentials: creds);
+
+        return Ok(new { token = new JwtSecurityTokenHandler().WriteToken(token) });
+    }
+}

--- a/WebApi/Middleware/JwtValidationMiddleware.cs
+++ b/WebApi/Middleware/JwtValidationMiddleware.cs
@@ -1,0 +1,75 @@
+using System.IdentityModel.Tokens.Jwt;
+using System.Security.Claims;
+using System.Text;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Configuration;
+using Microsoft.IdentityModel.Tokens;
+
+namespace WebApi.Middleware;
+
+public class JwtValidationMiddleware
+{
+    private readonly RequestDelegate _next;
+    private readonly IConfiguration _config;
+
+    public JwtValidationMiddleware(RequestDelegate next, IConfiguration config)
+    {
+        _next = next;
+        _config = config;
+    }
+
+    public async Task InvokeAsync(HttpContext context)
+    {
+        // allow token endpoint without validation
+        if (context.Request.Path.StartsWithSegments("/auth/token"))
+        {
+            await _next(context);
+            return;
+        }
+
+        var authHeader = context.Request.Headers["Authorization"].FirstOrDefault();
+        var token = authHeader?.StartsWith("Bearer ") == true ? authHeader[7..] : null;
+
+        if (string.IsNullOrEmpty(token))
+        {
+            context.Response.StatusCode = StatusCodes.Status401Unauthorized;
+            await context.Response.WriteAsync("Missing token");
+            return;
+        }
+
+        var tokenHandler = new JwtSecurityTokenHandler();
+        var key = Encoding.UTF8.GetBytes(_config["Jwt:Key"]!);
+
+        try
+        {
+            tokenHandler.ValidateToken(token, new TokenValidationParameters
+            {
+                ValidateIssuerSigningKey = true,
+                IssuerSigningKey = new SymmetricSecurityKey(key),
+                ValidateIssuer = true,
+                ValidateAudience = true,
+                ValidIssuer = _config["Jwt:Issuer"],
+                ValidAudience = _config["Jwt:Audience"],
+                ClockSkew = TimeSpan.Zero
+            }, out SecurityToken validatedToken);
+
+            var jwtToken = (JwtSecurityToken)validatedToken;
+            var identity = new ClaimsIdentity(jwtToken.Claims, "jwt");
+            context.User = new ClaimsPrincipal(identity);
+        }
+        catch
+        {
+            context.Response.StatusCode = StatusCodes.Status401Unauthorized;
+            await context.Response.WriteAsync("Invalid token");
+            return;
+        }
+
+        await _next(context);
+    }
+}
+
+public static class JwtValidationMiddlewareExtensions
+{
+    public static IApplicationBuilder UseJwtValidation(this IApplicationBuilder builder)
+        => builder.UseMiddleware<JwtValidationMiddleware>();
+}

--- a/WebApi/Models/LoginRequest.cs
+++ b/WebApi/Models/LoginRequest.cs
@@ -1,0 +1,3 @@
+namespace WebApi.Models;
+
+public record LoginRequest(string Username, string Password);

--- a/WebApi/Program.cs
+++ b/WebApi/Program.cs
@@ -1,3 +1,4 @@
+using WebApi.Middleware;
 var builder = WebApplication.CreateBuilder(args);
 
 // Add services to the container.
@@ -6,6 +7,9 @@ builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen();
 builder.Services.AddScoped<WebApi.Services.IHelloService, WebApi.Services.HelloService>();
 builder.Services.AddScoped<WebApi.Services.IWeatherForecastService, WebApi.Services.WeatherForecastService>();
+
+// required for JWT configuration in middleware
+builder.Services.AddSingleton<IConfiguration>(builder.Configuration);
 
 var app = builder.Build();
 
@@ -17,6 +21,9 @@ if (app.Environment.IsDevelopment())
 }
 
 app.UseHttpsRedirection();
+
+// custom middleware to validate JWT tokens
+app.UseJwtValidation();
 
 app.MapControllers();
 

--- a/WebApi/WebApi.csproj
+++ b/WebApi/WebApi.csproj
@@ -9,6 +9,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.16" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.6.2" />
+    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="7.4.1" />
   </ItemGroup>
 
 </Project>

--- a/WebApi/appsettings.Development.json
+++ b/WebApi/appsettings.Development.json
@@ -4,5 +4,10 @@
       "Default": "Information",
       "Microsoft.AspNetCore": "Warning"
     }
+  },
+  "Jwt": {
+    "Key": "ThisIsASecretKeyForJwtToken12345",
+    "Issuer": "FunApi",
+    "Audience": "FunApiUsers"
   }
 }

--- a/WebApi/appsettings.json
+++ b/WebApi/appsettings.json
@@ -6,4 +6,10 @@
     }
   },
   "AllowedHosts": "*"
+  ,
+  "Jwt": {
+    "Key": "ThisIsASecretKeyForJwtToken12345",
+    "Issuer": "FunApi",
+    "Audience": "FunApiUsers"
+  }
 }


### PR DESCRIPTION
## Summary
- add custom middleware to validate JWT tokens
- create `AuthController` to issue tokens for the `admin` user
- wire middleware in `Program.cs`
- define `LoginRequest` model
- add JWT settings in appsettings
- add JWT nuget package

## Testing
- `dotnet build` *(fails: `bash: dotnet: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68414a2c7a54833080afd261ff411e1a